### PR TITLE
Allow builds on macOS & copying to local plugin folder on non-windows systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    platform="macos"
+else
+    platform="linux"
+fi
+
 function iterate {
     for item in $(ls $1)
     do
@@ -23,12 +29,12 @@ function build_native {
 }
 
 function cmake_configure {
-    mkdir --parents "$1/build/linux"
-    cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Release -S "$1" -B "$1/build/linux" -G "Ninja"
+    mkdir -p "$1/build/$platform"
+    cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Release -S "$1" -B "$1/build/$platform" -G "Ninja"
 }
 
 function cmake_build {
-    cmake --build "$1/build/linux" --config Release --target all -j 4
+    cmake --build "$1/build/$platform" --config Release --target all -j 4
 }
 
 iterate "./lib"

--- a/src/NxEditor.EpdPlugin.csproj
+++ b/src/NxEditor.EpdPlugin.csproj
@@ -33,7 +33,12 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)\*.*&quot; &quot;%25LOCALAPPDATA%25\nx-editor\plugins\$(TargetName)\&quot; /Y /D" ContinueOnError="WarnAndContinue" />
+    <!-- Copy into plugins dir on anything that is not Windows, should work for both Linux & macOS -->
+    <Exec Condition="!$([MSBuild]::IsOsPlatform('Windows'))" Command="mkdir -p $HOME/.local/share/nx-editor/plugins/$(TargetName)/" />
+    <Exec Condition="!$([MSBuild]::IsOsPlatform('Windows'))" Command="cp -R $(TargetDir)/* $HOME/.local/share/nx-editor/plugins/$(TargetName)/" />
+    
+    <!-- Copy into plugins dir for Windows -->
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy &quot;$(TargetDir)\*.*&quot; &quot;%25LOCALAPPDATA%25\nx-editor\plugins\$(TargetName)\&quot; /Y /D" ContinueOnError="WarnAndContinue" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Adjusted the build script to build in a macos folder (used in submodules to find dynamic libraries) and to copy the build results into local plugin folders when ready.