### PR TITLE
Fix issue where material icons for SarcEditorView did not work properly

### DIFF
--- a/src/EpdPlugin.cs
+++ b/src/EpdPlugin.cs
@@ -4,6 +4,9 @@ using Native.IO.Services;
 using NxEditor.EpdPlugin.Processors;
 using NxEditor.EpdPlugin.Providers;
 using NxEditor.PluginBase;
+using Projektanker.Icons.Avalonia;
+using Projektanker.Icons.Avalonia.MaterialDesign;
+
 
 namespace NxEditor.EpdPlugin;
 
@@ -21,7 +24,7 @@ public class EpdPlugin : IServiceExtension
         Console.WriteLine($"Loaded cs_oead: {isOeadLoaded}");
         Console.WriteLine($"Loaded cs_msbt: {isMsbtLoaded}");
 
-        IconProvider.Current.Register(new MaterialSymbolIconProvider());
+        IconProvider.Current.Register(new MaterialDesignIconProvider());
 
         serviceManager
             .Register(new Yaz0Processor())

--- a/src/NxEditor.EpdPlugin.csproj
+++ b/src/NxEditor.EpdPlugin.csproj
@@ -36,6 +36,10 @@
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
+    <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="6.6.0">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Avalonia.Xaml.Interactions" Version="11.0.0">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/src/Views/SarcEditorView.axaml
+++ b/src/Views/SarcEditorView.axaml
@@ -225,10 +225,10 @@
                         <Button Command="{Binding FindNextCommand}"
                                 CommandParameter="True"
                                 ToolTip.Tip="Find/Replace Next">
-                            <pi:Icon Value="ms-find" />
+                            <pi:Icon Value="mdi-file-replace" />
                         </Button>
                         <Button Command="{Binding FindAll}" ToolTip.Tip="Find/Replace All">
-                            <pi:Icon Value="ms-find-and-replace" />
+                            <pi:Icon Value="mdi-file-replace" />
                         </Button>
                     </StackPanel>
                     <StackPanel Grid.Column="1"
@@ -237,13 +237,13 @@
                                 Orientation="Horizontal"
                                 Spacing="2.6">
                         <ToggleButton IsChecked="{Binding MatchCase}" ToolTip.Tip="Match Case">
-                            <pi:Icon Value="ms-match-case" />
+                            <pi:Icon Value="mdi-format-letter-case" />
                         </ToggleButton>
                         <ToggleButton IsEnabled="False" ToolTip.Tip="Match Whole Word">
-                            <pi:Icon Value="ms-match-word" />
+                            <pi:Icon Value="mdi-format-letter-matches" />
                         </ToggleButton>
                         <ToggleButton IsEnabled="False" ToolTip.Tip="Regex">
-                            <pi:Icon Value="ms-regex" />
+                            <pi:Icon Value="mdi-regex" />
                         </ToggleButton>
                     </StackPanel>
                 </Grid>


### PR DESCRIPTION
When building the plugin in isolation (I'm building these in completely separate folders from the NxEditor repo itself, dunno if it works out of the box when doing something like that) it fails due to not having a proper reference to the Material icons & the IconProvider. 

This addresses that issue and uses the standard `mdi` prefix for icons (the icons I chose are not great but couldn't find anything that gives a 1-1 replication of the default text editor find/replace icons).